### PR TITLE
Add an option to use ICU to locate word boundaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,13 @@ if (LITEHTML_UTF8)
   target_compile_definitions(${PROJECT_NAME} PUBLIC LITEHTML_UTF8)
 endif()
 
+# ICU
+option(USE_ICU "Use ICU to locate word boundaries in text elements" OFF)
+if (USE_ICU)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC USE_ICU)
+    target_link_libraries(${PROJECT_NAME} PUBLIC icui18n icuuc icudata)
+endif()
+
 # Gumbo
 target_link_libraries(${PROJECT_NAME} PUBLIC gumbo)
 

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -168,7 +168,7 @@ litehtml::document::ptr litehtml::document::createFromUTF8(const char* str, lite
 		doc->m_root->parse_styles();
 
 		// Now the m_tabular_elements is filled with tabular elements.
-		// We have to check the tabular elements for missing table elements 
+		// We have to check the tabular elements for missing table elements
 		// and create the anonymous boxes in visual table layout
 		doc->fix_tables_layout();
 
@@ -345,7 +345,7 @@ void litehtml::document::draw( uint_ptr hdc, int x, int y, const position* clip 
 int litehtml::document::cvt_units( const tchar_t* str, int fontSize, bool* is_percent/*= 0*/ ) const
 {
 	if(!str)	return 0;
-	
+
 	css_length val;
 	val.fromString(str);
 	if(is_percent && val.units() == css_units_percentage && !val.is_predefined())
@@ -461,9 +461,9 @@ bool litehtml::document::on_mouse_over( int x, int y, int client_x, int client_y
 		}
 		cursor = m_over_element->get_cursor();
 	}
-	
+
 	m_container->set_cursor(cursor ? cursor : _t("auto"));
-	
+
 	if(state_was_changed)
 	{
 		return m_root->find_styles_changes(redraw_boxes, 0, 0);
@@ -743,7 +743,7 @@ void litehtml::document::create_node(void* gnode, elements_vector& elements, boo
 				{
 					child.clear();
 					create_node(static_cast<GumboNode*> (node->v.element.children.data[i]), child, parseTextNode);
-					std::for_each(child.begin(), child.end(), 
+					std::for_each(child.begin(), child.end(),
 						[&ret](element::ptr& el)
 						{
 							ret->appendChild(el);
@@ -1012,7 +1012,7 @@ void litehtml::document::append_children_from_utf8(element& parent, const char* 
 		child->parse_styles();
 
 		// Now the m_tabular_elements is filled with tabular elements.
-		// We have to check the tabular elements for missing table elements 
+		// We have to check the tabular elements for missing table elements
 		// and create the anonymous boxes in visual table layout
 		fix_tables_layout();
 


### PR DESCRIPTION
Add a CMake option (USE_ICU) to enable the use of ICU to locate word
boundaries in strings. If USE_ICU is enabled then split_text_node()
uses ICU's BreakIterator to split up a text node. If USE_ICU is
disabled then split_text_node() uses the existing implementation to
split up a text node.

USE_ICU is disabled by default so this does not introduce a dependency
on ICU for existing litehtml users.