### PR TITLE
Add tstring_view, a string reference type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(SOURCE_LITEHTML
     src/style.cpp
     src/stylesheet.cpp
     src/table.cpp
+    src/tstring_view.cpp
     src/utf8_strings.cpp
     src/web_color.cpp
     src/num_cvt.cpp
@@ -104,6 +105,7 @@ set(HEADER_LITEHTML
     include/litehtml/style.h
     include/litehtml/stylesheet.h
     include/litehtml/table.h
+    include/litehtml/tstring_view.h
     include/litehtml/types.h
     include/litehtml/utf8_strings.h
     include/litehtml/web_color.h
@@ -117,6 +119,7 @@ set(TEST_LITEHTML
     test/documentTest.cpp
     test/layoutGlobalTest.cpp
     test/mediaQueryTest.cpp
+    test/tstring_view_test.cpp
     test/webColorTest.cpp
 )
 

--- a/include/litehtml/os_types.h
+++ b/include/litehtml/os_types.h
@@ -1,6 +1,8 @@
 #ifndef LH_OS_TYPES_H
 #define LH_OS_TYPES_H
 
+#include <string>
+
 namespace litehtml
 {
 #if defined( WIN32 ) || defined( _WIN32 ) || defined( WINCE )

--- a/include/litehtml/tstring_view.h
+++ b/include/litehtml/tstring_view.h
@@ -1,0 +1,135 @@
+// Copyright (C) 2020-2021 Primate Labs Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef LITEHTML_TSTRING_VIEW_H__
+#define LITEHTML_TSTRING_VIEW_H__
+
+#include <ostream>
+
+#include "litehtml/os_types.h"
+
+namespace litehtml {
+
+// tstring_view is a string reference type that provides a view into a string
+// that is owned elsewhere (e.g., by a std::string object).
+
+// tstring_view implements the same interface as std::base_string_view in the
+// standard library.  When litehtml moves to C++17 consider replacing the
+// tstring_view implementation with the standard library implementations
+// (e.g., via a using statement).
+
+class tstring_view {
+public:
+    using value_type = tchar_t;
+
+    using pointer = tchar_t*;
+
+    using const_pointer = const tchar_t*;
+
+    using reference = tchar_t&;
+
+    using const_reference = const tchar_t&;
+
+    using iterator = const_pointer;
+
+    using const_iterator = const_pointer;
+
+    using size_type = size_t;
+
+    using difference_type = ptrdiff_t;
+
+public:
+    tstring_view() = default;
+
+    tstring_view(const tstring_view& other) = default;
+
+    tstring_view(const_pointer s, size_type size)
+    : data_(s)
+    , size_(size)
+    {
+    }
+
+    constexpr const_iterator begin() const
+    {
+        return data_;
+    }
+
+    constexpr const_iterator cbegin() const
+    {
+        return data_;
+    }
+
+    constexpr const_iterator end() const
+    {
+        return data_ + size_;
+    }
+
+    constexpr const_iterator cend() const
+    {
+        return data_ + size_;
+    }
+
+    constexpr const_reference operator[](size_type offset) const
+    {
+        return *(data_ + offset);
+    }
+
+    constexpr const_pointer data() const
+    {
+        return data_;
+    }
+
+    size_type size() const
+    {
+        return size_;
+    }
+
+    size_type length() const
+    {
+        return size_;
+    }
+
+    bool empty() const
+    {
+        return (size_ == 0);
+    }
+
+private:
+    const_pointer data_ = nullptr;
+
+    size_type size_ = 0;
+};
+
+std::basic_ostream<tstring_view::value_type>& operator<<(
+    std::basic_ostream<tstring_view::value_type>&,
+    tstring_view str);
+
+} // namespace litehtml
+
+#endif // LITEHTML_TSTRING_VIEW_H__

--- a/src/tstring_view.cpp
+++ b/src/tstring_view.cpp
@@ -1,0 +1,46 @@
+// Copyright (C) 2020-2021 Primate Labs Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "litehtml/tstring_view.h"
+
+namespace litehtml {
+
+
+std::basic_ostream<tstring_view::value_type>& operator<<(
+    std::basic_ostream<tstring_view::value_type>& os,
+    tstring_view str)
+{
+    if (os.good()) {
+        os.write(str.data(), str.size());
+    }
+
+    return os;
+}
+
+} // namespace litehtml

--- a/test/tstring_view_test.cpp
+++ b/test/tstring_view_test.cpp
@@ -1,0 +1,77 @@
+// Copyright (C) 2020-2021 Primate Labs Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "litehtml/tstring_view.h"
+
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+using namespace litehtml;
+
+TEST(TStringViewTest, DefaultConstructor)
+{
+    tstring_view view;
+
+    EXPECT_EQ(nullptr, view.data());
+    EXPECT_EQ(0, view.size());
+    EXPECT_TRUE(view.empty());
+}
+
+TEST(TStringViewTest, Constructor)
+{
+    constexpr size_t offset = 5;
+    constexpr size_t length = 10;
+
+    tstring string = _t("the quick brown fox jumps over the lazy dog");
+    tstring_view view(string.data() + offset, length);
+
+    EXPECT_EQ(string.data() + offset, view.data());
+    EXPECT_EQ(length, view.size());
+    EXPECT_FALSE(view.empty());
+
+    for (size_t i = 0; i < view.size(); i++) {
+        EXPECT_EQ(string[offset + i], view[i]);
+    }
+}
+
+TEST(TStringViewTest, RangeForLoop)
+{
+    constexpr size_t offset = 5;
+    constexpr size_t length = 10;
+
+    tstring string = _t("the quick brown fox jumps over the lazy dog");
+    tstring_view view(string.data() + offset, length);
+
+    for (auto c : view) {
+        // TODO: How can we automatically (rather than manually) verify the
+        // iterator is working properly here?
+        std::cout << c << std::endl;
+    }
+}


### PR DESCRIPTION
tstring_view is a string reference type that provides a view into a
string that is owned elsewhere (e.g., by a std::string object).

tstring_view implements the same interface as std::base_string_view in
the standard library.  When litehtml moves to C++17 consider replacing
the tstring_view implementation with the standard library
implementations (e.g., via a using statement).