### PR TITLE
Add a headless litehtml command-line tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,11 @@ set(HEADER_LITEHTML
     include/litehtml/num_cvt.h
 )
 
+set(SOURCE_HEADLESS
+    src/headless/headless.cpp
+    src/headless/headless_container.cpp
+)
+
 set(TEST_LITEHTML
     containers/test/container_test.cpp
     test/contextTest.cpp
@@ -175,6 +180,42 @@ else()
         COMMAND cat ${CMAKE_CURRENT_SOURCE_DIR}/include/master.css | xxd -i > ${CMAKE_CURRENT_SOURCE_DIR}/src/master.css.inc)
 endif()
 set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/master.css.inc PROPERTIES GENERATED TRUE)
+
+# Headless
+option(BUILD_HEADLESS "Build headless litehtml browser" OFF)
+if (BUILD_HEADLESS)
+    find_package(PkgConfig)
+    pkg_search_module(CAIRO REQUIRED cairo>=1.12.0)
+    pkg_search_module(FONTCONFIG REQUIRED fontconfig>=2.0.0)
+    set(HEADLESS_NAME headless)
+    add_executable(
+        ${HEADLESS_NAME}
+        ${SOURCE_HEADLESS}
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/master.css.inc
+    )
+    set_target_properties(${HEADLESS_NAME} PROPERTIES
+        CXX_STANDARD 11
+        C_STANDARD 99
+    )
+    target_include_directories(
+        ${HEADLESS_NAME}
+        PUBLIC
+        ${CAIRO_INCLUDE_DIRS}
+        ${FONTCONFIG_INCLUDE_DIRS}
+    )
+    target_link_directories(
+        ${HEADLESS_NAME}
+        PUBLIC
+        ${CAIRO_LIBRARY_DIRS}
+        ${FONTCONFIG_LIBRARY_DIRS}
+    )
+    target_link_libraries(
+        ${HEADLESS_NAME}
+        ${PROJECT_NAME}
+        ${CAIRO_LIBRARIES}
+        ${FONTCONFIG_LIBRARIES}
+    )
+endif()
 
 # Tests
 

--- a/src/headless/headless.cpp
+++ b/src/headless/headless.cpp
@@ -1,0 +1,87 @@
+// Copyright (C) 2020-2021 Primate Labs Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include "litehtml.h"
+
+#include "headless/headless_container.h"
+
+namespace {
+
+const litehtml::tchar_t master_stylesheet[] =
+{
+#include "master.css.inc"
+, 0
+};
+
+std::string load(const std::string& filename)
+{
+    std::ifstream ifs(filename);
+
+    if (ifs.bad()) {
+        exit(-1);
+    }
+
+    std::string data;
+    char c;
+    // TODO: Is there a better way to load a file into memory?
+    while (ifs.get(c)) {
+        data += c;
+    }
+
+    return data;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    std::string html = load(argv[1]);
+
+    litehtml::context ctx;
+    ctx.load_master_stylesheet(master_stylesheet);
+
+    headless_container container;
+    litehtml::document::ptr doc = litehtml::document::createFromString(html.c_str(), &container, &ctx);
+
+    doc->render(1000);
+
+	cairo_surface_t* surface  = cairo_image_surface_create(CAIRO_FORMAT_RGB24, doc->width(), doc->height());
+    cairo_t* cr = cairo_create(surface);
+
+    cairo_set_source_rgb(cr, 1.0, 1.0, 1.0);
+    cairo_paint(cr);
+
+    doc->draw((litehtml::uint_ptr)cr, 0, 0, nullptr);
+    cairo_surface_write_to_png(surface, "headless.png");
+
+    return 0;
+}

--- a/src/headless/headless_container.cpp
+++ b/src/headless/headless_container.cpp
@@ -33,8 +33,6 @@
 #define _USE_MATH_DEFINES
 #include <math.h>
 
-#include <iostream>
-
 #include <cairo-ft.h>
 #include <fontconfig/fontconfig.h>
 
@@ -54,9 +52,8 @@ headless_container::headless_container(void)
 
 headless_container::~headless_container(void)
 {
-    clear_images();
-    cairo_surface_destroy(temporary_surface_);
     cairo_destroy(temporary_cr_);
+    cairo_surface_destroy(temporary_surface_);
 }
 
 litehtml::uint_ptr headless_container::create_font(const litehtml::tchar_t* faceName,
@@ -165,8 +162,6 @@ int headless_container::text_width(const litehtml::tchar_t* text, litehtml::uint
     cairo_text_extents(temporary_cr_, text, &ext);
 
     cairo_restore(temporary_cr_);
-
-    std::cout << text << " " << ext.x_advance << std::endl;
 
     return (int)ext.x_advance;
 }
@@ -682,8 +677,10 @@ void headless_container::apply_clip(cairo_t* cr)
 void headless_container::draw_ellipse(cairo_t* cr, int x, int y, int width,
   int height, const litehtml::web_color& color, int line_width)
 {
-    if (!cr)
+    if (!cr) {
         return;
+    }
+
     cairo_save(cr);
 
     apply_clip(cr);
@@ -704,8 +701,10 @@ void headless_container::draw_ellipse(cairo_t* cr, int x, int y, int width,
 void headless_container::fill_ellipse(cairo_t* cr, int x, int y, int width,
   int height, const litehtml::web_color& color)
 {
-    if (!cr)
+    if (!cr) {
         return;
+    }
+
     cairo_save(cr);
 
     apply_clip(cr);
@@ -731,15 +730,6 @@ cairo_surface_t* headless_container::get_image(const litehtml::tchar_t* url,
 
 void headless_container::clear_images()
 {
-    /*	for(images_map::iterator i = m_images.begin(); i != m_images.end(); i++)
-            {
-                    if(i->second)
-                    {
-                            delete i->second;
-                    }
-            }
-            m_images.clear();
-    */
 }
 
 const litehtml::tchar_t* headless_container::get_default_font_name() const

--- a/src/headless/headless_container.cpp
+++ b/src/headless/headless_container.cpp
@@ -1,0 +1,837 @@
+// Copyright (c) 2013, Yuri Kobets (tordex)
+// Copyright (C) 2020-2021 Primate Labs Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "headless/headless_container.h"
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+
+#include <iostream>
+
+#include <cairo-ft.h>
+#include <fontconfig/fontconfig.h>
+
+namespace {
+
+constexpr int kDefaultWidth = 1000;
+constexpr int kDefaultHeight = 1000;
+constexpr int kDefaultDPI = 144;
+
+} // namespace
+
+headless_container::headless_container(void)
+{
+    temporary_surface_ = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, kDefaultWidth, kDefaultHeight);
+    temporary_cr_ = cairo_create(temporary_surface_);
+}
+
+headless_container::~headless_container(void)
+{
+    clear_images();
+    cairo_surface_destroy(temporary_surface_);
+    cairo_destroy(temporary_cr_);
+}
+
+litehtml::uint_ptr headless_container::create_font(const litehtml::tchar_t* faceName,
+    int size,
+    int weight,
+    litehtml::font_style italic,
+    unsigned int decoration,
+    litehtml::font_metrics* fm)
+{
+    litehtml::string_vector fonts;
+    litehtml::split_string(faceName, fonts, ",");
+    litehtml::trim(fonts[0]);
+
+    cairo_font_face_t* fnt = 0;
+
+    FcPattern* pattern = FcPatternCreate();
+    bool found = false;
+    for (litehtml::string_vector::iterator i = fonts.begin(); i != fonts.end(); i++) {
+        if (FcPatternAddString(pattern, FC_FAMILY, (unsigned char*)i->c_str())) {
+            found = true;
+            break;
+        }
+    }
+    if (found) {
+        if (italic == litehtml::fontStyleItalic) {
+            FcPatternAddInteger(pattern, FC_SLANT, FC_SLANT_ITALIC);
+        } else {
+            FcPatternAddInteger(pattern, FC_SLANT, FC_SLANT_ROMAN);
+        }
+
+        int fc_weight = FC_WEIGHT_NORMAL;
+        if (weight >= 0 && weight < 150)
+            fc_weight = FC_WEIGHT_THIN;
+        else if (weight >= 150 && weight < 250)
+            fc_weight = FC_WEIGHT_EXTRALIGHT;
+        else if (weight >= 250 && weight < 350)
+            fc_weight = FC_WEIGHT_LIGHT;
+        else if (weight >= 350 && weight < 450)
+            fc_weight = FC_WEIGHT_NORMAL;
+        else if (weight >= 450 && weight < 550)
+            fc_weight = FC_WEIGHT_MEDIUM;
+        else if (weight >= 550 && weight < 650)
+            fc_weight = FC_WEIGHT_SEMIBOLD;
+        else if (weight >= 650 && weight < 750)
+            fc_weight = FC_WEIGHT_BOLD;
+        else if (weight >= 750 && weight < 850)
+            fc_weight = FC_WEIGHT_EXTRABOLD;
+        else if (weight >= 950)
+            fc_weight = FC_WEIGHT_BLACK;
+
+        FcPatternAddInteger(pattern, FC_WEIGHT, fc_weight);
+
+        fnt = cairo_ft_font_face_create_for_pattern(pattern);
+    }
+
+    FcPatternDestroy(pattern);
+
+    cairo_font* ret = 0;
+
+    if (fm && fnt) {
+        cairo_save(temporary_cr_);
+
+        cairo_set_font_face(temporary_cr_, fnt);
+        cairo_set_font_size(temporary_cr_, size);
+        cairo_font_extents_t ext;
+        cairo_font_extents(temporary_cr_, &ext);
+
+        cairo_text_extents_t tex;
+        cairo_text_extents(temporary_cr_, "x", &tex);
+
+        fm->ascent = (int)ext.ascent;
+        fm->descent = (int)ext.descent;
+        fm->height = (int)(ext.ascent + ext.descent);
+        fm->x_height = (int)tex.height;
+
+        cairo_restore(temporary_cr_);
+
+        ret = new cairo_font;
+        ret->font = fnt;
+        ret->size = size;
+        ret->strikeout = (decoration & litehtml::font_decoration_linethrough) ? true : false;
+        ret->underline = (decoration & litehtml::font_decoration_underline) ? true : false;
+    }
+
+    return (litehtml::uint_ptr)ret;
+}
+
+void headless_container::delete_font(litehtml::uint_ptr hFont)
+{
+    cairo_font* fnt = (cairo_font*)hFont;
+    if (fnt) {
+        cairo_font_face_destroy(fnt->font);
+        delete fnt;
+    }
+}
+
+int headless_container::text_width(const litehtml::tchar_t* text, litehtml::uint_ptr hFont)
+{
+    cairo_font* fnt = (cairo_font*)hFont;
+
+    cairo_save(temporary_cr_);
+
+    cairo_set_font_size(temporary_cr_, fnt->size);
+    cairo_set_font_face(temporary_cr_, fnt->font);
+    cairo_text_extents_t ext;
+    cairo_text_extents(temporary_cr_, text, &ext);
+
+    cairo_restore(temporary_cr_);
+
+    std::cout << text << " " << ext.x_advance << std::endl;
+
+    return (int)ext.x_advance;
+}
+
+void headless_container::draw_text(litehtml::uint_ptr hdc, const litehtml::tchar_t* text,
+  litehtml::uint_ptr hFont, litehtml::web_color color, const litehtml::position& pos)
+{
+    cairo_font* fnt = (cairo_font*)hFont;
+    cairo_t* cr = (cairo_t*)hdc;
+    cairo_save(cr);
+
+    apply_clip(cr);
+
+    cairo_set_font_face(cr, fnt->font);
+    cairo_set_font_size(cr, fnt->size);
+    cairo_font_extents_t ext;
+    cairo_font_extents(cr, &ext);
+
+    int x = pos.left();
+    int y = pos.bottom() - ext.descent;
+
+    set_color(cr, color);
+
+    cairo_move_to(cr, x, y);
+    cairo_show_text(cr, text);
+
+    int tw = 0;
+
+    if (fnt->underline || fnt->strikeout) {
+        tw = text_width(text, hFont);
+    }
+
+    if (fnt->underline) {
+        cairo_set_line_width(cr, 1);
+        cairo_move_to(cr, x, y + 1.5);
+        cairo_line_to(cr, x + tw, y + 1.5);
+        cairo_stroke(cr);
+    }
+    if (fnt->strikeout) {
+        cairo_text_extents_t tex;
+        cairo_text_extents(cr, "x", &tex);
+
+        int ln_y = y - tex.height / 2.0;
+
+        cairo_set_line_width(cr, 1);
+        cairo_move_to(cr, x, (double)ln_y - 0.5);
+        cairo_line_to(cr, x + tw, (double)ln_y - 0.5);
+        cairo_stroke(cr);
+    }
+
+    cairo_restore(cr);
+}
+
+int headless_container::pt_to_px(int pt)
+{
+    return (int)((double)pt * kDefaultDPI / 72.0);
+}
+
+int headless_container::get_default_font_size() const
+{
+    return 16;
+}
+
+void headless_container::draw_list_marker(
+  litehtml::uint_ptr hdc, const litehtml::list_marker& marker)
+{
+    if (!marker.image.empty()) {
+        /*litehtml::tstring url;
+        make_url(marker.image.c_str(), marker.baseurl, url);
+
+        lock_images_cache();
+        images_map::iterator img_i = m_images.find(url.c_str());
+        if(img_i != m_images.end())
+        {
+                if(img_i->second)
+                {
+                        draw_txdib((cairo_t*) hdc, img_i->second, marker.pos.x,
+        marker.pos.y, marker.pos.width, marker.pos.height);
+                }
+        }
+        unlock_images_cache();*/
+    } else {
+        switch (marker.marker_type) {
+            case litehtml::list_style_type_circle: {
+                draw_ellipse((cairo_t*)hdc, marker.pos.x, marker.pos.y,
+                  marker.pos.width, marker.pos.height, marker.color, 0.5);
+            } break;
+            case litehtml::list_style_type_disc: {
+                fill_ellipse((cairo_t*)hdc, marker.pos.x, marker.pos.y,
+                  marker.pos.width, marker.pos.height, marker.color);
+            } break;
+            case litehtml::list_style_type_square:
+                if (hdc) {
+                    cairo_t* cr = (cairo_t*)hdc;
+                    cairo_save(cr);
+
+                    cairo_new_path(cr);
+                    cairo_rectangle(cr, marker.pos.x, marker.pos.y,
+                      marker.pos.width, marker.pos.height);
+
+                    set_color(cr, marker.color);
+                    cairo_fill(cr);
+                    cairo_restore(cr);
+                }
+                break;
+            default:
+                /*do nothing*/
+                break;
+        }
+    }
+}
+
+void headless_container::load_image(const litehtml::tchar_t* src,
+    const litehtml::tchar_t* baseurl,
+    bool redraw_on_ready)
+{
+    litehtml::tstring url;
+    make_url(src, baseurl, url);
+    if (m_images.find(url.c_str()) == m_images.end()) {
+        try {
+            cairo_surface_t* img = get_image(url.c_str(), true);
+            if (img) {
+                m_images[url.c_str()] = img;
+            }
+        } catch (...) {
+            int iii = 0;
+            iii++;
+        }
+    }
+}
+
+void headless_container::get_image_size(const litehtml::tchar_t* src,
+    const litehtml::tchar_t* baseurl,
+    litehtml::size& sz)
+{
+    litehtml::tstring url;
+    make_url(src, baseurl, url);
+
+    images_map::iterator img = m_images.find(url.c_str());
+    if (img != m_images.end()) {
+        sz.width = cairo_image_surface_get_width(img->second);
+        sz.height = cairo_image_surface_get_height(img->second);
+    } else {
+        sz.width = 0;
+        sz.height = 0;
+    }
+}
+
+void headless_container::draw_background(litehtml::uint_ptr hdc,
+    const litehtml::background_paint& bg)
+{
+    cairo_t* cr = (cairo_t*)hdc;
+    cairo_save(cr);
+    apply_clip(cr);
+
+    rounded_rectangle(cr, bg.border_box, bg.border_radius);
+    cairo_clip(cr);
+
+    cairo_rectangle(
+      cr, bg.clip_box.x, bg.clip_box.y, bg.clip_box.width, bg.clip_box.height);
+    cairo_clip(cr);
+
+    if (bg.color.alpha) {
+        set_color(cr, bg.color);
+        cairo_paint(cr);
+    }
+
+    litehtml::tstring url;
+    make_url(bg.image.c_str(), bg.baseurl.c_str(), url);
+
+    // lock_images_cache();
+    images_map::iterator img_i = m_images.find(url.c_str());
+    if (img_i != m_images.end() && img_i->second) {
+        // Glib::RefPtr<Gdk::Pixbuf> bgbmp = img_i->second;
+
+        // Glib::RefPtr<Gdk::Pixbuf> new_img;
+        // if(bg.image_size.width != bgbmp->get_width() || bg.image_size.height
+        // != bgbmp->get_height())
+        //{
+        //	new_img = bgbmp->scale_simple(bg.image_size.width,
+        // bg.image_size.height, Gdk::INTERP_BILINEAR);
+        //	bgbmp = new_img;
+        //}
+
+        cairo_surface_t* img = img_i->second;
+        cairo_pattern_t* pattern = cairo_pattern_create_for_surface(img);
+        cairo_matrix_t flib_m;
+        cairo_matrix_init_identity(&flib_m);
+        cairo_matrix_translate(&flib_m, -bg.position_x, -bg.position_y);
+        cairo_pattern_set_extend(pattern, CAIRO_EXTEND_REPEAT);
+        cairo_pattern_set_matrix(pattern, &flib_m);
+
+        switch (bg.repeat) {
+            case litehtml::background_repeat_no_repeat:
+                //draw_pixbuf(cr, bgbmp, bg.position_x, bg.position_y,
+                //  bgbmp->get_width(), bgbmp->get_height());
+                break;
+
+            case litehtml::background_repeat_repeat_x:
+                //cairo_set_source(cr, pattern);
+                //cairo_rectangle(cr, bg.clip_box.left(), bg.position_y,
+                //  bg.clip_box.width, bgbmp->get_height());
+                cairo_fill(cr);
+                break;
+
+            case litehtml::background_repeat_repeat_y:
+                //cairo_set_source(cr, pattern);
+                //cairo_rectangle(cr, bg.position_x, bg.clip_box.top(),
+                //  bgbmp->get_width(), bg.clip_box.height);
+                //cairo_fill(cr);
+                break;
+
+            case litehtml::background_repeat_repeat:
+                //cairo_set_source(cr, pattern);
+                //cairo_rectangle(cr, bg.clip_box.left(), bg.clip_box.top(),
+                //  bg.clip_box.width, bg.clip_box.height);
+                //cairo_fill(cr);
+                break;
+        }
+
+        cairo_pattern_destroy(pattern);
+        cairo_surface_destroy(img);
+    }
+    //	unlock_images_cache();
+    cairo_restore(cr);
+}
+
+void headless_container::make_url(const litehtml::tchar_t* url,
+  const litehtml::tchar_t* basepath, litehtml::tstring& out)
+{
+    out = url;
+}
+
+void headless_container::add_path_arc(cairo_t* cr, double x, double y,
+  double rx, double ry, double a1, double a2, bool neg)
+{
+    if (rx > 0 && ry > 0) {
+        cairo_save(cr);
+
+        cairo_translate(cr, x, y);
+        cairo_scale(cr, 1, ry / rx);
+        cairo_translate(cr, -x, -y);
+
+        if (neg) {
+            cairo_arc_negative(cr, x, y, rx, a1, a2);
+        } else {
+            cairo_arc(cr, x, y, rx, a1, a2);
+        }
+
+        cairo_restore(cr);
+    } else {
+        cairo_move_to(cr, x, y);
+    }
+}
+
+void headless_container::draw_borders(litehtml::uint_ptr hdc,
+    const litehtml::borders& borders,
+    const litehtml::position& draw_pos,
+    bool root)
+{
+    cairo_t* cr = (cairo_t*)hdc;
+    cairo_save(cr);
+    apply_clip(cr);
+
+    cairo_new_path(cr);
+
+    int bdr_top = 0;
+    int bdr_bottom = 0;
+    int bdr_left = 0;
+    int bdr_right = 0;
+
+    if (borders.top.width != 0 && borders.top.style > litehtml::border_style_hidden) {
+        bdr_top = (int)borders.top.width;
+    }
+    if (borders.bottom.width != 0 && borders.bottom.style > litehtml::border_style_hidden) {
+        bdr_bottom = (int)borders.bottom.width;
+    }
+    if (borders.left.width != 0 && borders.left.style > litehtml::border_style_hidden) {
+        bdr_left = (int)borders.left.width;
+    }
+    if (borders.right.width != 0 && borders.right.style > litehtml::border_style_hidden) {
+        bdr_right = (int)borders.right.width;
+    }
+
+    // draw right border
+    if (bdr_right) {
+        set_color(cr, borders.right.color);
+
+        double r_top = borders.radius.top_right_x;
+        double r_bottom = borders.radius.bottom_right_x;
+
+        if (r_top) {
+            double end_angle = 2 * M_PI;
+            double start_angle =
+              end_angle - M_PI / 2.0 / ((double)bdr_top / (double)bdr_right + 1);
+
+            add_path_arc(cr, draw_pos.right() - r_top, draw_pos.top() + r_top,
+              r_top - bdr_right, r_top - bdr_right + (bdr_right - bdr_top),
+              end_angle, start_angle, true);
+
+            add_path_arc(cr, draw_pos.right() - r_top, draw_pos.top() + r_top,
+              r_top, r_top, start_angle, end_angle, false);
+        } else {
+            cairo_move_to(cr, draw_pos.right() - bdr_right, draw_pos.top() + bdr_top);
+            cairo_line_to(cr, draw_pos.right(), draw_pos.top());
+        }
+
+        if (r_bottom) {
+            cairo_line_to(cr, draw_pos.right(), draw_pos.bottom() - r_bottom);
+
+            double start_angle = 0;
+            double end_angle =
+              start_angle + M_PI / 2.0 / ((double)bdr_bottom / (double)bdr_right + 1);
+
+            add_path_arc(cr, draw_pos.right() - r_bottom, draw_pos.bottom() - r_bottom,
+              r_bottom, r_bottom, start_angle, end_angle, false);
+
+            add_path_arc(cr, draw_pos.right() - r_bottom, draw_pos.bottom() - r_bottom,
+              r_bottom - bdr_right, r_bottom - bdr_right + (bdr_right - bdr_bottom),
+              end_angle, start_angle, true);
+        } else {
+            cairo_line_to(cr, draw_pos.right(), draw_pos.bottom());
+            cairo_line_to(cr, draw_pos.right() - bdr_right, draw_pos.bottom() - bdr_bottom);
+        }
+
+        cairo_fill(cr);
+    }
+
+    // draw bottom border
+    if (bdr_bottom) {
+        set_color(cr, borders.bottom.color);
+
+        double r_left = borders.radius.bottom_left_x;
+        double r_right = borders.radius.bottom_right_x;
+
+        if (r_left) {
+            double start_angle = M_PI / 2.0;
+            double end_angle =
+              start_angle + M_PI / 2.0 / ((double)bdr_left / (double)bdr_bottom + 1);
+
+            add_path_arc(cr, draw_pos.left() + r_left, draw_pos.bottom() - r_left,
+              r_left - bdr_bottom + (bdr_bottom - bdr_left),
+              r_left - bdr_bottom, start_angle, end_angle, false);
+
+            add_path_arc(cr, draw_pos.left() + r_left, draw_pos.bottom() - r_left,
+              r_left, r_left, end_angle, start_angle, true);
+        } else {
+            cairo_move_to(cr, draw_pos.left(), draw_pos.bottom());
+            cairo_line_to(cr, draw_pos.left() + bdr_left, draw_pos.bottom() - bdr_bottom);
+        }
+
+        if (r_right) {
+            cairo_line_to(cr, draw_pos.right() - r_right, draw_pos.bottom());
+
+            double end_angle = M_PI / 2.0;
+            double start_angle =
+              end_angle - M_PI / 2.0 / ((double)bdr_right / (double)bdr_bottom + 1);
+
+            add_path_arc(cr, draw_pos.right() - r_right, draw_pos.bottom() - r_right,
+              r_right, r_right, end_angle, start_angle, true);
+
+            add_path_arc(cr, draw_pos.right() - r_right, draw_pos.bottom() - r_right,
+              r_right - bdr_bottom + (bdr_bottom - bdr_right),
+              r_right - bdr_bottom, start_angle, end_angle, false);
+        } else {
+            cairo_line_to(cr, draw_pos.right() - bdr_right, draw_pos.bottom() - bdr_bottom);
+            cairo_line_to(cr, draw_pos.right(), draw_pos.bottom());
+        }
+
+        cairo_fill(cr);
+    }
+
+    // draw top border
+    if (bdr_top) {
+        set_color(cr, borders.top.color);
+
+        double r_left = borders.radius.top_left_x;
+        double r_right = borders.radius.top_right_x;
+
+        if (r_left) {
+            double end_angle = M_PI * 3.0 / 2.0;
+            double start_angle =
+              end_angle - M_PI / 2.0 / ((double)bdr_left / (double)bdr_top + 1);
+
+            add_path_arc(cr, draw_pos.left() + r_left, draw_pos.top() + r_left,
+              r_left, r_left, end_angle, start_angle, true);
+
+            add_path_arc(cr, draw_pos.left() + r_left, draw_pos.top() + r_left,
+              r_left - bdr_top + (bdr_top - bdr_left), r_left - bdr_top,
+              start_angle, end_angle, false);
+        } else {
+            cairo_move_to(cr, draw_pos.left(), draw_pos.top());
+            cairo_line_to(cr, draw_pos.left() + bdr_left, draw_pos.top() + bdr_top);
+        }
+
+        if (r_right) {
+            cairo_line_to(cr, draw_pos.right() - r_right, draw_pos.top() + bdr_top);
+
+            double start_angle = M_PI * 3.0 / 2.0;
+            double end_angle =
+              start_angle + M_PI / 2.0 / ((double)bdr_right / (double)bdr_top + 1);
+
+            add_path_arc(cr, draw_pos.right() - r_right, draw_pos.top() + r_right,
+              r_right - bdr_top + (bdr_top - bdr_right), r_right - bdr_top,
+              start_angle, end_angle, false);
+
+            add_path_arc(cr, draw_pos.right() - r_right, draw_pos.top() + r_right,
+              r_right, r_right, end_angle, start_angle, true);
+        } else {
+            cairo_line_to(cr, draw_pos.right() - bdr_right, draw_pos.top() + bdr_top);
+            cairo_line_to(cr, draw_pos.right(), draw_pos.top());
+        }
+
+        cairo_fill(cr);
+    }
+
+    // draw left border
+    if (bdr_left) {
+        set_color(cr, borders.left.color);
+
+        double r_top = borders.radius.top_left_x;
+        double r_bottom = borders.radius.bottom_left_x;
+
+        if (r_top) {
+            double start_angle = M_PI;
+            double end_angle =
+              start_angle + M_PI / 2.0 / ((double)bdr_top / (double)bdr_left + 1);
+
+            add_path_arc(cr, draw_pos.left() + r_top, draw_pos.top() + r_top,
+              r_top - bdr_left, r_top - bdr_left + (bdr_left - bdr_top),
+              start_angle, end_angle, false);
+
+            add_path_arc(cr, draw_pos.left() + r_top, draw_pos.top() + r_top,
+              r_top, r_top, end_angle, start_angle, true);
+        } else {
+            cairo_move_to(cr, draw_pos.left() + bdr_left, draw_pos.top() + bdr_top);
+            cairo_line_to(cr, draw_pos.left(), draw_pos.top());
+        }
+
+        if (r_bottom) {
+            cairo_line_to(cr, draw_pos.left(), draw_pos.bottom() - r_bottom);
+
+            double end_angle = M_PI;
+            double start_angle =
+              end_angle - M_PI / 2.0 / ((double)bdr_bottom / (double)bdr_left + 1);
+
+            add_path_arc(cr, draw_pos.left() + r_bottom, draw_pos.bottom() - r_bottom,
+              r_bottom, r_bottom, end_angle, start_angle, true);
+
+            add_path_arc(cr, draw_pos.left() + r_bottom, draw_pos.bottom() - r_bottom,
+              r_bottom - bdr_left, r_bottom - bdr_left + (bdr_left - bdr_bottom),
+              start_angle, end_angle, false);
+        } else {
+            cairo_line_to(cr, draw_pos.left(), draw_pos.bottom());
+            cairo_line_to(cr, draw_pos.left() + bdr_left, draw_pos.bottom() - bdr_bottom);
+        }
+
+        cairo_fill(cr);
+    }
+    cairo_restore(cr);
+}
+
+void headless_container::transform_text(litehtml::tstring& text, litehtml::text_transform tt)
+{
+}
+
+void headless_container::import_css(litehtml::tstring& text,
+    const litehtml::tstring& url,
+    litehtml::tstring& baseurl)
+{
+}
+
+void headless_container::set_clip(const litehtml::position& pos,
+    const litehtml::border_radiuses& bdr_radius,
+    bool valid_x,
+    bool valid_y)
+{
+    litehtml::position clip_pos = pos;
+    litehtml::position client_pos;
+    get_client_rect(client_pos);
+    if (!valid_x) {
+        clip_pos.x = client_pos.x;
+        clip_pos.width = client_pos.width;
+    }
+    if (!valid_y) {
+        clip_pos.y = client_pos.y;
+        clip_pos.height = client_pos.height;
+    }
+    m_clips.emplace_back(clip_pos, bdr_radius);
+}
+
+void headless_container::del_clip()
+{
+    if (!m_clips.empty()) {
+        m_clips.pop_back();
+    }
+}
+
+void headless_container::get_client_rect(litehtml::position& client) const
+{
+    client.width = kDefaultWidth;
+    client.height = kDefaultHeight;
+}
+
+void headless_container::apply_clip(cairo_t* cr)
+{
+    for (const auto& clip_box : m_clips) {
+        rounded_rectangle(cr, clip_box.box, clip_box.radius);
+        cairo_clip(cr);
+    }
+}
+
+void headless_container::draw_ellipse(cairo_t* cr, int x, int y, int width,
+  int height, const litehtml::web_color& color, int line_width)
+{
+    if (!cr)
+        return;
+    cairo_save(cr);
+
+    apply_clip(cr);
+
+    cairo_new_path(cr);
+
+    cairo_translate(cr, x + width / 2.0, y + height / 2.0);
+    cairo_scale(cr, width / 2.0, height / 2.0);
+    cairo_arc(cr, 0, 0, 1, 0, 2 * M_PI);
+
+    set_color(cr, color);
+    cairo_set_line_width(cr, line_width);
+    cairo_stroke(cr);
+
+    cairo_restore(cr);
+}
+
+void headless_container::fill_ellipse(cairo_t* cr, int x, int y, int width,
+  int height, const litehtml::web_color& color)
+{
+    if (!cr)
+        return;
+    cairo_save(cr);
+
+    apply_clip(cr);
+
+    cairo_new_path(cr);
+
+    cairo_translate(cr, x + width / 2.0, y + height / 2.0);
+    cairo_scale(cr, width / 2.0, height / 2.0);
+    cairo_arc(cr, 0, 0, 1, 0, 2 * M_PI);
+
+    set_color(cr, color);
+    cairo_fill(cr);
+
+    cairo_restore(cr);
+}
+
+cairo_surface_t* headless_container::get_image(const litehtml::tchar_t* url,
+    bool redraw_on_ready)
+{
+    return nullptr;
+}
+
+
+void headless_container::clear_images()
+{
+    /*	for(images_map::iterator i = m_images.begin(); i != m_images.end(); i++)
+            {
+                    if(i->second)
+                    {
+                            delete i->second;
+                    }
+            }
+            m_images.clear();
+    */
+}
+
+const litehtml::tchar_t* headless_container::get_default_font_name() const
+{
+    return "Times New Roman";
+}
+
+std::shared_ptr<litehtml::element> headless_container::create_element(
+    const litehtml::tchar_t* tag_name,
+    const litehtml::string_map& attributes,
+    const std::shared_ptr<litehtml::document>& doc)
+{
+    return 0;
+}
+
+void headless_container::rounded_rectangle(cairo_t* cr,
+    const litehtml::position& pos,
+    const litehtml::border_radiuses& radius)
+{
+    cairo_new_path(cr);
+    if (radius.top_left_x) {
+        cairo_arc(cr, pos.left() + radius.top_left_x, pos.top() + radius.top_left_x,
+          radius.top_left_x, M_PI, M_PI * 3.0 / 2.0);
+    } else {
+        cairo_move_to(cr, pos.left(), pos.top());
+    }
+
+    cairo_line_to(cr, pos.right() - radius.top_right_x, pos.top());
+
+    if (radius.top_right_x) {
+        cairo_arc(cr, pos.right() - radius.top_right_x, pos.top() + radius.top_right_x,
+          radius.top_right_x, M_PI * 3.0 / 2.0, 2.0 * M_PI);
+    }
+
+    cairo_line_to(cr, pos.right(), pos.bottom() - radius.bottom_right_x);
+
+    if (radius.bottom_right_x) {
+        cairo_arc(cr, pos.right() - radius.bottom_right_x,
+          pos.bottom() - radius.bottom_right_x, radius.bottom_right_x, 0, M_PI / 2.0);
+    }
+
+    cairo_line_to(cr, pos.left() - radius.bottom_left_x, pos.bottom());
+
+    if (radius.bottom_left_x) {
+        cairo_arc(cr, pos.left() + radius.bottom_left_x,
+          pos.bottom() - radius.bottom_left_x, radius.bottom_left_x, M_PI / 2.0, M_PI);
+    }
+}
+
+void headless_container::get_media_features(litehtml::media_features& media) const
+{
+    litehtml::position client;
+    get_client_rect(client);
+    media.type = litehtml::media_type_screen;
+    media.width = client.width;
+    media.height = client.height;
+    media.device_width = kDefaultWidth;
+    media.device_height = kDefaultHeight;
+    media.color = 8;
+    media.monochrome = 0;
+    media.color_index = 256;
+    media.resolution = kDefaultDPI;
+}
+
+void headless_container::get_language(litehtml::tstring& language,
+    litehtml::tstring& culture) const
+{
+    language = _t("en");
+    culture = _t("");
+}
+
+void headless_container::set_caption(const litehtml::tchar_t*)
+{
+
+}
+
+void headless_container::set_base_url(const litehtml::tchar_t* base_url)
+{
+
+}
+
+void headless_container::link(const std::shared_ptr<litehtml::document>& ptr,
+  const litehtml::element::ptr& el)
+{
+}
+
+void headless_container::on_anchor_click(const litehtml::tchar_t* url,
+    const litehtml::element::ptr& el)
+{
+
+}
+
+void headless_container::set_cursor(const litehtml::tchar_t* cursor)
+{
+}

--- a/src/headless/headless_container.h
+++ b/src/headless/headless_container.h
@@ -78,6 +78,7 @@ protected:
 
 public:
     headless_container();
+
     virtual ~headless_container();
 
     virtual litehtml::uint_ptr create_font(const litehtml::tchar_t* faceName,
@@ -166,8 +167,6 @@ public:
 
     virtual cairo_surface_t* get_image(const litehtml::tchar_t* url,
         bool redraw_on_ready);
-
-    void clear_images();
 
 protected:
     virtual void draw_ellipse(cairo_t* cr, int x, int y, int width, int height,

--- a/src/headless/headless_container.h
+++ b/src/headless/headless_container.h
@@ -1,0 +1,209 @@
+// Copyright (c) 2013, Yuri Kobets (tordex)
+// Copyright (C) 2020-2021 Primate Labs Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef HEADLESS_HEADLESS_CONTAINER_H__
+#define HEADLESS_HEADLESS_CONTAINER_H__
+
+#include <cairo.h>
+
+#include "litehtml.h"
+
+struct cairo_clip_box {
+    typedef std::vector<cairo_clip_box> vector;
+    litehtml::position box;
+    litehtml::border_radiuses radius;
+
+    cairo_clip_box(const litehtml::position& vBox, litehtml::border_radiuses vRad)
+    {
+        box = vBox;
+        radius = vRad;
+    }
+
+    cairo_clip_box(const cairo_clip_box& val)
+    {
+        box = val.box;
+        radius = val.radius;
+    }
+
+    cairo_clip_box& operator=(const cairo_clip_box& val)
+    {
+        box = val.box;
+        radius = val.radius;
+        return *this;
+    }
+};
+
+struct cairo_font {
+    cairo_font_face_t* font;
+    int size;
+    bool underline;
+    bool strikeout;
+};
+
+class headless_container : public litehtml::document_container {
+    typedef std::map<litehtml::tstring, cairo_surface_t*> images_map;
+
+protected:
+    cairo_surface_t* temporary_surface_;
+    cairo_t* temporary_cr_;
+    images_map m_images;
+    cairo_clip_box::vector m_clips;
+
+public:
+    headless_container();
+    virtual ~headless_container();
+
+    virtual litehtml::uint_ptr create_font(const litehtml::tchar_t* faceName,
+        int size, int weight,
+	    litehtml::font_style italic,
+        unsigned int decoration,
+	    litehtml::font_metrics* fm) override;
+
+    virtual void delete_font(litehtml::uint_ptr hFont) override;
+
+	virtual int text_width(const litehtml::tchar_t* text,
+        litehtml::uint_ptr hFont) override;
+
+	virtual void draw_text(litehtml::uint_ptr hdc,
+        const litehtml::tchar_t* text,
+        litehtml::uint_ptr hFont,
+        litehtml::web_color color,
+        const litehtml::position& pos) override;
+
+	virtual int pt_to_px(int pt) override;
+
+	virtual int get_default_font_size() const override;
+
+	virtual const litehtml::tchar_t* get_default_font_name() const override;
+
+    virtual void load_image(const litehtml::tchar_t* src,
+        const litehtml::tchar_t* baseurl,
+        bool redraw_on_ready) override;
+
+    virtual void get_image_size(const litehtml::tchar_t* src,
+        const litehtml::tchar_t* baseurl,
+        litehtml::size& sz) override;
+
+    virtual void draw_background(litehtml::uint_ptr hdc,
+        const litehtml::background_paint& bg) override;
+
+    virtual void draw_borders(litehtml::uint_ptr hdc,
+        const litehtml::borders& borders,
+        const litehtml::position& draw_pos,
+        bool root) override;
+
+    virtual void draw_list_marker(litehtml::uint_ptr hdc,
+        const litehtml::list_marker& marker) override;
+
+    virtual std::shared_ptr<litehtml::element> create_element(
+        const litehtml::tchar_t* tag_name,
+        const litehtml::string_map& attributes,
+        const std::shared_ptr<litehtml::document>& doc) override;
+
+    virtual void get_media_features(litehtml::media_features& media) const override;
+
+    virtual void get_language(litehtml::tstring& language,
+        litehtml::tstring& culture) const override;
+
+	virtual	void set_caption(const litehtml::tchar_t*) override;
+
+    virtual	void set_base_url(const litehtml::tchar_t* base_url) override;
+
+    virtual void link(const std::shared_ptr<litehtml::document>& ptr,
+        const litehtml::element::ptr& el) override;
+
+	virtual void on_anchor_click(const litehtml::tchar_t* url,
+        const litehtml::element::ptr& el) override;
+
+	virtual	void set_cursor(const litehtml::tchar_t* cursor) override;
+
+    virtual void transform_text(litehtml::tstring& text,
+        litehtml::text_transform tt) override;
+
+    virtual void import_css(litehtml::tstring& text,
+        const litehtml::tstring& url,
+        litehtml::tstring& baseurl) override;
+
+    virtual void set_clip(const litehtml::position& pos,
+        const litehtml::border_radiuses& bdr_radius,
+        bool valid_x,
+        bool valid_y) override;
+
+    virtual void del_clip() override;
+
+    virtual void get_client_rect(litehtml::position& client) const override;
+
+    virtual void make_url(const litehtml::tchar_t* url,
+        const litehtml::tchar_t* basepath,
+        litehtml::tstring& out);
+
+    virtual cairo_surface_t* get_image(const litehtml::tchar_t* url,
+        bool redraw_on_ready);
+
+    void clear_images();
+
+protected:
+    virtual void draw_ellipse(cairo_t* cr, int x, int y, int width, int height,
+        const litehtml::web_color& color, int line_width);
+
+    virtual void fill_ellipse(cairo_t* cr,
+        int x,
+        int y,
+        int width,
+        int height,
+        const litehtml::web_color& color);
+
+    virtual void rounded_rectangle(cairo_t* cr,
+        const litehtml::position& pos,
+        const litehtml::border_radiuses& radius);
+
+private:
+    void apply_clip(cairo_t* cr);
+
+    void add_path_arc(cairo_t* cr,
+        double x,
+        double y,
+        double rx,
+        double ry,
+        double a1,
+        double a2,
+        bool neg);
+
+    void set_color(cairo_t* cr, litehtml::web_color color)
+    {
+        cairo_set_source_rgba(cr,
+            color.red / 255.0,
+            color.green / 255.0,
+            color.blue / 255.0,
+            color.alpha / 255.0);
+    }
+};
+
+#endif // HEADLESS_HEADLESS_CONTAINER_H__


### PR DESCRIPTION
headless is a command-line tool that uses litehtml to render an HTML
document.  headless can only render HTML documents from the local file
system (i.e., it cannot load HTML documents over HTTP or HTTPS).  The
rendered document is saved to a PNG file in the current directory.

headless is meant to provide a way to quickly and easily render HTML
while working on the litehtml engine itself.

headless is not built by default as it requires cairo and fontconfig
for its container implementation (which is based on container_linux
with the GTK components removed).  Pass BUILD_HEADLESS=1 to CMake
to build headless.
